### PR TITLE
p2 password as row of revealable stars

### DIFF
--- a/tom_eso/forms.py
+++ b/tom_eso/forms.py
@@ -12,7 +12,8 @@ class ESOProfileForm(forms.ModelForm):
     p2_password = forms.CharField(
         required=False,
         label="P2 password",
-        help_text="Enter your Phase 2 Tool password. Leave blank to keep unchanged."
+        help_text="Enter your Phase 2 Tool password. Leave blank to keep unchanged.",
+        widget=forms.PasswordInput(render_value=True)
     )
 
     def __init__(self, *args, **kwargs):

--- a/tom_eso/templates/tom_eso/eso_update_user_profile.html
+++ b/tom_eso/templates/tom_eso/eso_update_user_profile.html
@@ -15,3 +15,10 @@
     </form>
 </div>
 {% endblock %}
+{% block extra_javascript %}
+<script type="text/javascript">
+document.getElementById('id_p2_password').addEventListener('focus', function() {
+  this.value = '';
+});
+</script>
+{% endblock %}

--- a/tom_eso/templates/tom_eso/partials/eso_user_profile.html
+++ b/tom_eso/templates/tom_eso/partials/eso_user_profile.html
@@ -20,7 +20,21 @@
             {% for field_data in profile_data_list %}
                 {% if field_data.value %}
                     <dt class="col-sm-6">{{ field_data.label }}</dt>
-                    <dd class="col-sm-6">{{ field_data.value }}</dd>
+                    <dd class="col-sm-6">
+                        {% if field_data.is_password %}
+                            <input
+                                type="password"
+                                readonly
+                                value="{{ field_data.value }}"
+                                title="Click to reveal"
+                                class="form-control-plaintext p-0"
+                                style="cursor:pointer;"
+                                onclick="this.type = this.type === 'password' ? 'text' : 'password'"
+                            />
+                        {% else %}
+                            {{ field_data.value }}
+                        {% endif %}
+                    </dd>
                 {% endif %}
                 {% empty %}
                     <p>No ESO Profile items yet for this user.</p>

--- a/tom_eso/templates/tom_eso/partials/eso_user_profile.html
+++ b/tom_eso/templates/tom_eso/partials/eso_user_profile.html
@@ -13,7 +13,7 @@
     </div>
     <div class="card-body">
         <p>
-            ESO P2 Tool Configuraton and Credentials
+            ESO P2 Tool Configuration and Credentials
         </p>
         <hr />
         <dl class="row">

--- a/tom_eso/templates/tom_eso/partials/eso_user_profile.html
+++ b/tom_eso/templates/tom_eso/partials/eso_user_profile.html
@@ -22,15 +22,17 @@
                     <dt class="col-sm-6">{{ field_data.label }}</dt>
                     <dd class="col-sm-6">
                         {% if field_data.is_password %}
-                            <input
-                                type="password"
-                                readonly
-                                value="{{ field_data.value }}"
-                                title="Click to reveal"
-                                class="form-control-plaintext p-0"
-                                style="cursor:pointer;"
-                                onclick="this.type = this.type === 'password' ? 'text' : 'password'"
-                            />
+                            <div style="cursor:pointer;"
+                                 title="Click to reveal"
+                                 onclick="var i=this.querySelector('input'); i.type = i.type === 'password' ? 'text':'password';">
+                                <input
+                                    type="password"
+                                    readonly
+                                    value="{{ field_data.value }}"
+                                    class="form-control-plaintext p-0"
+                                    style="display:inline; width:auto; cursor:pointer;"
+                                /> <i class="fa fa-eye"></i>
+                            </div>
                         {% else %}
                             {{ field_data.value }}
                         {% endif %}

--- a/tom_eso/templates/tom_eso/partials/eso_user_profile.html
+++ b/tom_eso/templates/tom_eso/partials/eso_user_profile.html
@@ -22,17 +22,7 @@
                     <dt class="col-sm-6">{{ field_data.label }}</dt>
                     <dd class="col-sm-6">
                         {% if field_data.is_password %}
-                            <div style="cursor:pointer;"
-                                 title="Click to reveal"
-                                 onclick="var i=this.querySelector('input'); i.type = i.type === 'password' ? 'text':'password';">
-                                <input
-                                    type="password"
-                                    readonly
-                                    value="{{ field_data.value }}"
-                                    class="form-control-plaintext p-0"
-                                    style="display:inline; width:auto; cursor:pointer;"
-                                /> <i class="fa fa-eye"></i>
-                            </div>
+                           {% include 'tom_common/partials/revealable_password_input.html' with value=field_data.value %}
                         {% else %}
                             {{ field_data.value }}
                         {% endif %}

--- a/tom_eso/templatetags/eso_extras.py
+++ b/tom_eso/templatetags/eso_extras.py
@@ -56,6 +56,8 @@ def eso_profile_data(user) -> dict:
     if decrypted_password is None:
         password_value = "[Password not available]"
 
-    profile_data_list.append({'label': password_label, 'value': password_value})
+    profile_data_list.append(
+        {"label": password_label, "value": password_value, "is_password": True}
+    )
 
     return {'user': user, 'eso_profile': profile, 'profile_data_list': profile_data_list}


### PR DESCRIPTION
Hides the password on the profile page, making the password on revealed on click.
Also uses a proper password widget on the actual update form.
Solves https://github.com/TOMToolkit/tom_base/issues/1451 for this app, at least.